### PR TITLE
Add variable for disk partition to work with attached nvme storage types

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,3 +2,4 @@
 # Aditional disks that need to be formated and mouted.
 # See README for syntax and usage.
 disk_additional_disks: []
+disk_partition: 1

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,10 +14,10 @@
     if
         [ -b {{ item.disk }} ]
     then
-        [ -b {{ item.disk }}1 ] || parted --script "{{ item.disk }}" mklabel gpt mkpart primary 1MiB 100%
+        [ -b {{ item.disk }}{{ disk.partition }} ] || parted --script "{{ item.disk }}" mklabel gpt mkpart primary 1MiB 100%
     fi
   args:
-    creates: '{{ item.disk }}1'
+    creates: '{{ item.disk }}{{ disk.partition }}'
     executable: '/bin/bash'
   with_items: '{{ disk_additional_disks }}'
   tags:
@@ -25,7 +25,7 @@
 
 - name: Create filesystem on the first partition
   filesystem:
-    dev: '{{ item.disk }}1'
+    dev: '{{ item.disk }}{{ disk.partition }}'
     force: '{{ item.force|d(omit) }}'
     fstype: '{{ item.fstype }}'
     opts: '{{ item.fsopts|d(omit) }}'
@@ -44,7 +44,7 @@
     - disk
 
 - name: Get UUID for partition
-  command: blkid -s UUID -o value "{{ item.disk }}1"
+  command: blkid -s UUID -o value "{{ item.disk }}{{ disk.partition }}"
   register: disk_blkid
   with_items: '{{ disk_additional_disks }}'
   changed_when: False


### PR DESCRIPTION
The defaults will continue to work for all existing implementations. 

Installations that require the attached instance storage (which lists partitions as p1) will need to specify the variable appropriately.