### PR TITLE
Fix partition var

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,4 +2,3 @@
 # Aditional disks that need to be formated and mouted.
 # See README for syntax and usage.
 disk_additional_disks: []
-disk_partition: 1

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,10 +14,10 @@
     if
         [ -b {{ item.disk }} ]
     then
-        [ -b {{ item.disk }}{{ disk.partition }} ] || parted --script "{{ item.disk }}" mklabel gpt mkpart primary 1MiB 100%
+        [ -b {{ item.disk }}{{ item.disk_partition  }} ] || parted --script "{{ item.disk }}" mklabel gpt mkpart primary 1MiB 100%
     fi
   args:
-    creates: '{{ item.disk }}{{ disk.partition }}'
+    creates: '{{ item.disk }}{{ item.disk_partition  }}'
     executable: '/bin/bash'
   with_items: '{{ disk_additional_disks }}'
   tags:
@@ -25,7 +25,7 @@
 
 - name: Create filesystem on the first partition
   filesystem:
-    dev: '{{ item.disk }}{{ disk.partition }}'
+    dev: '{{ item.disk }}{{ item.disk_partition  }}'
     force: '{{ item.force|d(omit) }}'
     fstype: '{{ item.fstype }}'
     opts: '{{ item.fsopts|d(omit) }}'
@@ -44,7 +44,7 @@
     - disk
 
 - name: Get UUID for partition
-  command: blkid -s UUID -o value "{{ item.disk }}{{ disk.partition }}"
+  command: blkid -s UUID -o value "{{ item.disk }}{{ item.disk_partition  }}"
   register: disk_blkid
   with_items: '{{ disk_additional_disks }}'
   changed_when: False


### PR DESCRIPTION
This includes:

correctly reference the disk partition
moved this var into the additional_disk block. Reason for this is then we can have two different partition types if needed. This is a breaking change though and will need an additional var when being run